### PR TITLE
Check for open api version to set render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/swagger-ui-layout",
-      "version": "0.1.0",
+      "version": "0.2.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@parcel/packager-ts": "^2.13.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.2.0-alpha.2",
+  "version": "0.2.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/swagger-ui-layout",
-      "version": "0.2.0-alpha.2",
+      "version": "0.2.0-alpha.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@parcel/packager-ts": "^2.13.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/swagger-ui-layout",
-      "version": "0.2.0-alpha.3",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@parcel/packager-ts": "^2.13.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/swagger-ui-layout",
-      "version": "0.2.0-alpha.1",
+      "version": "0.2.0-alpha.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@parcel/packager-ts": "^2.13.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "types": "dist/types.d.ts",
   "type": "module",
   "scripts": {
-    "build": "parcel build"
+    "build": "parcel build",
+    "watch": "parcel watch"
   },
   "keywords": [
     "swagger-ui"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.2.0-alpha.2",
+  "version": "0.2.0-alpha.3",
   "description": "A library of Swagger UI layout plugins.",
   "main": "dist/main.js",
+  "module": "dist/module.js",
   "css": "dist/main.css",
   "targets": {
     "main": {
+      "source": "src/index.ts"
+    },
+    "module": {
       "source": "src/index.ts"
     },
     "css": {
@@ -13,7 +17,6 @@
     }
   },
   "types": "dist/types.d.ts",
-  "type": "module",
   "scripts": {
     "build": "parcel build",
     "watch": "parcel watch"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "description": "A library of Swagger UI layout plugins.",
   "main": "dist/main.js",
   "css": "dist/main.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0",
   "description": "A library of Swagger UI layout plugins.",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/swagger-ui-layout",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.1",
   "description": "A library of Swagger UI layout plugins.",
   "main": "dist/main.js",
   "css": "dist/main.css",

--- a/src/wrapComponents/SpanOpenAPIVersion.tsx
+++ b/src/wrapComponents/SpanOpenAPIVersion.tsx
@@ -7,7 +7,25 @@ const SpanOpenAPIVersion = function(system: any) {
     wrapComponents: {
       OpenAPIVersion: (Original: any, system: any) => (props: SpanOpenAPIVersionProps) => {
         const classList = "version version-stamp version-stamp--openapi version-stamp--span";
-        const { oasVersion } = props;
+        let { oasVersion } = props;
+        if (typeof system.specSelectors?.isOAS31 === "function") {
+          if (system.specSelectors.isOAS31()) {
+            return (
+              <span className={classList}>
+                OAS 3.1
+              </span>
+            );
+          }
+        }
+        if (typeof system.specSelectors?.isOAS30 === "function") {
+          if (system.specSelectors.isOAS30()) {
+            return (
+              <span className={classList}>
+                OAS 3.0
+              </span>
+            );
+          }
+        }
         return (
           <span className={classList}>
             { oasVersion }


### PR DESCRIPTION
Using the helpers from Swagger, this PR checks the open api version and writes out 3.1 or 3.0 as needed. If it isn't one of those, it will just out the version passed in. 

https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/oas3/helpers.jsx